### PR TITLE
Using LinkedHashSet to avoid inconsistency

### DIFF
--- a/src/main/scala/com/gravity/goose/extractors/ContentExtractor.scala
+++ b/src/main/scala/com/gravity/goose/extractors/ContentExtractor.scala
@@ -291,7 +291,7 @@ trait ContentExtractor {
     var startingBoost: Double = 1.0
     var cnt: Int = 0
     var i: Int = 0
-    val parentNodes = mutable.HashSet[Element]()
+    val parentNodes = mutable.LinkedHashSet[Element]()
     val nodesWithText = mutable.Buffer[Element]()
     for (node <- nodesToCheck) {
       val nodeText: String = node.text


### PR DESCRIPTION
Goose uses a HashSet for iterating topNode candidates
But HashSet doesn't guarantee ordering, so when two candidates have
the same score, the choice is basically random. This is not acceptable.
When upgrading jsoup, jsoup 1.8.2 updated hashCode calculation for the <article tag, the problem became evident through our tests and was discovered.
Now, by using LinkedHashSet we make sure that in case of draw, we choose
the first tag that was found in the DOM tree.
